### PR TITLE
Use new to create RuntimeException object

### DIFF
--- a/topics/monix-task-foundations/creationandexecution.md
+++ b/topics/monix-task-foundations/creationandexecution.md
@@ -53,7 +53,7 @@ If we'd like to create a `Task` that signals an error, we could use `Task.raiseE
 ```scala 
 import monix.eval.Task
 
-val error = Task.raiseError(RuntimeException("Something went wrong"))
+val error = Task.raiseError(new RuntimeException("Something went wrong"))
 ```
 
 `Task` will also catch any _non-fatal_ errors that are thrown and return them as a failed task.


### PR DESCRIPTION
This is a small fix. If new keyword is not used then the snippet throws -

`class java.lang.RuntimeException is not a value`